### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/block.php
+++ b/syntax/block.php
@@ -31,7 +31,7 @@ class syntax_plugin_plaintext_block extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 return array($state);
@@ -47,7 +47,7 @@ class syntax_plugin_plaintext_block extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         if($format == 'xhtml'){
             list($state) = $data;
             switch ($state) {

--- a/syntax/inline.php
+++ b/syntax/inline.php
@@ -26,14 +26,14 @@ class syntax_plugin_plaintext_inline extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         return substr($match,6,-7);
     }
 
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         if($format == 'xhtml'){
             $renderer->doc .= str_replace( "\n", "<br/>".DOKU_LF, trim($renderer->_xmlEntities($data),"\n") );
             return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
